### PR TITLE
Update style.css

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -87,7 +87,7 @@ ul{
 }
 /*----*/
 .top-nav span.menu:before{
-	content: url(../images/menu.png)no-repeat 0px 0px;
+	content: url(../images/menu.png);
 	cursor:pointer;
 	width:100%;
 }


### PR DESCRIPTION
Removed "no-repeat 0px 0px" from .top-nav span.menu:before as it was invalid and therefore stopped the mobile menu icon from displaying. Thought about adding in:
background-size: 0px 0px;
background-repeat: no-repeat;
to make up for these to being deleted but this is a content image and not a background image those two lines don't seem to serve any purpose.