### PR TITLE
Meta "description" is included twice

### DIFF
--- a/templates/default.html.twig
+++ b/templates/default.html.twig
@@ -11,7 +11,6 @@
         {% endfor %}
 
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="description" content="{{ site.metadata.description }}" />
       {% endblock %}
 
       {% block head_title %}


### PR DESCRIPTION
Meta tag "description" is included twice in the header. I remove the second one on line 14 of 'default.twig.html'